### PR TITLE
BLT-148 Fix nginx configuration for Consul

### DIFF
--- a/nginx-templates/default.conf.template
+++ b/nginx-templates/default.conf.template
@@ -9,7 +9,7 @@ server {
 
     location / {
         root   /usr/share/nginx/html;
-        index  index.html index.html;
+        index  index.html index.htm;
     }
 
     location /api/ {

--- a/nginx-templates/default.conf.template
+++ b/nginx-templates/default.conf.template
@@ -9,11 +9,14 @@ server {
 
     location / {
         root   /usr/share/nginx/html;
-        index  index.html index.htm;
+        index  index.html index.html;
     }
 
     location /api/ {
         proxy_pass http://backend/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
     }
 
     # redirect server error pages to the static page /50x.html
@@ -23,4 +26,3 @@ server {
         root   /usr/share/nginx/html;
     }
 }
-


### PR DESCRIPTION
The frontend service cannot retrieve data from the backend database, resulting in a 426 Error: Upgrade Required. This configuration fixes the issue.